### PR TITLE
GuardがコマンドラインからSporkサーバを使うようにする．

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -3,7 +3,7 @@ require 'active_support/inflector'
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', all_after_pass: false do
+guard 'rspec', all_after_pass: false, cli: '--drb' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }


### PR DESCRIPTION
* Guardfileのguard変数に:cli => --drbを追加する．