### PR TITLE
フレンドリーフォワーディングの転送のテストコードを追加する．

### DIFF
--- a/spec/requests/authentication_pages_spec.rb
+++ b/spec/requests/authentication_pages_spec.rb
@@ -61,6 +61,17 @@ describe "AuthenticationPages" do
 					it "should render the desired protected page" do
 						expect(page).to have_title('Edit user')
 					end
+
+					describe " when signing in agein" do 
+						before do
+							delete signout_path
+							sign_in user
+						end
+
+						it "should render the default(profile) page" do
+							expect(page).to have_title(user.name)
+						end
+					end
 				end
 			end
 
@@ -68,6 +79,15 @@ describe "AuthenticationPages" do
 				describe "visiting the edit page" do
 					before { visit edit_user_path(user) }
 					it { should have_title('Sign in')}
+
+					describe "Forward to edit page" do
+						before do
+							fill_in "Email",	with: user.email
+							fill_in "Password",	with: user.password
+							click_button "Sign in"
+						end
+						it { should have_title('Edit user') }
+					end
 				end
 
 				describe "submitting to the update action" do
@@ -78,6 +98,15 @@ describe "AuthenticationPages" do
 				describe "visiting the user index" do
 					before { visit users_path }
 					it { should have_title('Sign in') }
+
+					describe "Forward to user-index page" do
+						before do
+							fill_in "Email",	with: user.email
+							fill_in "Password",	with: user.password
+							click_button "Sign in"
+						end
+						it { should have_title('All users') }
+					end
 				end
 			end
 


### PR DESCRIPTION
* 続けてサインインを行った時，転送先がユーザプロファイルページに転送されているかを確認する．
* 最初に与えられたURLにのみ転送されていることを確認する．