### PR TITLE
destroyアクションを改造して，管理者が自分自身を削除できないようにする．

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,9 +39,9 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    User.find(params[:id]).destroy
-    flash[:success] = "User destroyed."
-    redirect_to users_url
+      User.find(params[:id]).destroy
+      flash[:success] = "User destroyed."
+      redirect_to users_url
   end
 
   private
@@ -64,6 +64,7 @@ class UsersController < ApplicationController
 
     def admin_user
       redirect_to(root_path) unless current_user.admin?
+      redirect_to(root_path) if current_user.id == params[:id].to_i
     end
 
 end

--- a/spec/requests/authentication_pages_spec.rb
+++ b/spec/requests/authentication_pages_spec.rb
@@ -110,5 +110,18 @@ describe "AuthenticationPages" do
 				specify { expect(response).to redirect_to(root_path) }
 			end
 		end
+
+		describe "as admin user" do
+			let(:admin_user) { FactoryGirl.create(:user) }
+			before do
+				admin_user.admin = true
+				sign_in admin_user, no_capybara: true
+				delete user_path(admin_user)
+			end
+
+			specify { expect(response).to redirect_to(root_path) }
+
+
+		end
 	end
 end


### PR DESCRIPTION
* current_userのidとparams[:id]を比較して，管理者が自分自身を削除できないようにする．